### PR TITLE
Add a primitive type declaration for f's result.

### DIFF
--- a/clj.clj
+++ b/clj.clj
@@ -1,4 +1,4 @@
-(defn f [^long n]
+(defn f ^long [^long n]
   (if (> n 1)
     (+ (f (- n 1)) (f (- n 2)))
     1))


### PR DESCRIPTION
Without this declaration, the underlying Object return type makes f's
result be boxed into a Long object. This change will improve the
performance of the code.
